### PR TITLE
feat: Add Mute Overlay (HUD) and Audio Feedback

### DIFF
--- a/toggleMute/toggleMute.xcodeproj/project.pbxproj
+++ b/toggleMute/toggleMute.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		BD391AE9263C3F5600848049 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = BD391AE8263C3F5600848049 /* LaunchAtLogin */; };
 		C3C528C02DF0162800BBC393 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = C3C528BF2DF0162800BBC393 /* KeyboardShortcuts */; };
 		C3DA000A2B88C00900B6BCCA /* EventMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DA00092B88C00900B6BCCA /* EventMonitor.swift */; };
+		MH001A0001000001 /* SoundFeedbackManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = MH001A0001000000 /* SoundFeedbackManager.swift */; };
+		MH001A0002000001 /* MuteHUDWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = MH001A0002000000 /* MuteHUDWindowController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -51,6 +53,8 @@
 		44EB8BD723AC2ABD005A4A0B /* TouchBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchBarController.swift; sourceTree = "<group>"; };
 		44EB8BDB23AC350D005A4A0B /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		C3DA00092B88C00900B6BCCA /* EventMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMonitor.swift; sourceTree = "<group>"; };
+		MH001A0001000000 /* SoundFeedbackManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundFeedbackManager.swift; sourceTree = "<group>"; };
+		MH001A0002000000 /* MuteHUDWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MuteHUDWindowController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -73,6 +77,7 @@
 				447B1DF8236795F100587E3A /* MainController.swift */,
 				44EB8BDB23AC350D005A4A0B /* SettingsViewController.swift */,
 				44EB8BD723AC2ABD005A4A0B /* TouchBarController.swift */,
+				MH001A0002000000 /* MuteHUDWindowController.swift */,
 			);
 			path = Controllers;
 			sourceTree = "<group>";
@@ -132,6 +137,7 @@
 				449F398223173003008A0DBD /* Preferences.swift */,
 				44D551DD2390830E0065505A /* SettingsController-Bridging-Header.h */,
 				44EB8BD623AC28E3005A4A0B /* NSTouchBar-Private.h */,
+				MH001A0001000000 /* SoundFeedbackManager.swift */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -274,6 +280,8 @@
 				449F398D23173610008A0DBD /* SettingsController.swift in Sources */,
 				449F398323173003008A0DBD /* Preferences.swift in Sources */,
 				C3DA000A2B88C00900B6BCCA /* EventMonitor.swift in Sources */,
+				MH001A0001000001 /* SoundFeedbackManager.swift in Sources */,
+				MH001A0002000001 /* MuteHUDWindowController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/toggleMute/toggleMute/Bootstrap/AppDelegate.swift
+++ b/toggleMute/toggleMute/Bootstrap/AppDelegate.swift
@@ -122,6 +122,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
         
         touchBarController.configureUI()
         
+        // Pre-warm singletons so NSPanel and NSSound are ready before first toggle
+        DispatchQueue.main.async {
+            _ = SoundFeedbackManager.shared
+            _ = MuteHUDWindowController.shared
+        }
+        
         KeyboardShortcuts.onKeyDown(for: .toggleMuteShortcut) {
             self.touchBarController.toggleMuteState()
             print("start")

--- a/toggleMute/toggleMute/Controllers/MuteHUDWindowController.swift
+++ b/toggleMute/toggleMute/Controllers/MuteHUDWindowController.swift
@@ -44,7 +44,7 @@ final class MuteHUDWindowController {
             let cfg = NSImage.SymbolConfiguration(pointSize: 72, weight: .regular)
             iconView.image = img.withSymbolConfiguration(cfg)
         }
-        iconView.contentTintColor = muted ? .systemRed : .white
+        iconView.contentTintColor = muted ? .systemRed : .labelColor
         label.stringValue = muted ? "Muted" : "Unmuted"
 
         positionWindow()
@@ -75,7 +75,7 @@ final class MuteHUDWindowController {
         container.wantsLayer = true
 
         let blur = NSVisualEffectView(frame: container.bounds)
-        blur.material = .hudWindow
+        blur.material = .popover
         blur.blendingMode = .behindWindow
         blur.state = .active
         blur.wantsLayer = true
@@ -97,7 +97,7 @@ final class MuteHUDWindowController {
         tf.drawsBackground = false
         tf.alignment = .center
         tf.font = .systemFont(ofSize: 18, weight: .bold)
-        tf.textColor = NSColor(white: 1.0, alpha: 0.85) 
+        tf.textColor = .labelColor
         tf.autoresizingMask = [.minXMargin, .maxXMargin]
         blur.addSubview(tf)
         label = tf

--- a/toggleMute/toggleMute/Controllers/MuteHUDWindowController.swift
+++ b/toggleMute/toggleMute/Controllers/MuteHUDWindowController.swift
@@ -1,0 +1,140 @@
+import Cocoa
+
+final class MuteHUDWindowController {
+
+    static let shared = MuteHUDWindowController()
+    private var preferences = Preferences()
+
+    private let hudSize = CGSize(width: 200, height: 200)
+
+    private lazy var hudWindow: NSPanel = {
+        let panel = NSPanel(
+            contentRect: NSRect(origin: .zero, size: hudSize),
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: true
+        )
+        panel.level = .modalPanel
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = false
+        panel.collectionBehavior = [.canJoinAllSpaces, .stationary, .ignoresCycle]
+        panel.isMovable = false
+        panel.contentView = buildContentView()
+        return panel
+    }()
+
+    private var iconView: NSImageView!
+    private var label: NSTextField!
+
+    private var dismissWork: DispatchWorkItem?
+
+    private init() {}
+
+    // MARK: - Public API
+
+    func show(muted: Bool) {
+        guard preferences.showHudEnabled else { return }
+
+        let window = hudWindow
+
+        // Update content (using contentTintColor for macOS 11 compatibility)
+        let symbolName = muted ? "mic.slash.fill" : "mic.fill"
+        if let img = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil) {
+            let cfg = NSImage.SymbolConfiguration(pointSize: 72, weight: .regular)
+            iconView.image = img.withSymbolConfiguration(cfg)
+        }
+        iconView.contentTintColor = muted ? .systemRed : .white
+        label.stringValue = muted ? "Muted" : "Unmuted"
+
+        positionWindow()
+
+        dismissWork?.cancel()
+
+        if let layer = window.contentView?.layer {
+            layer.removeAllAnimations()
+            layer.opacity = 1.0
+        }
+        
+        // Immediately make visible
+        window.alphaValue = 1.0
+        window.orderFrontRegardless()
+
+        // Schedule fade-out after 1.0 s
+        let work = DispatchWorkItem { [weak self] in
+            self?.fadeOut()
+        }
+        dismissWork = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: work)
+    }
+
+    // MARK: - Private helpers
+
+    private func buildContentView() -> NSView {
+        let container = NSView(frame: NSRect(origin: .zero, size: hudSize))
+        container.wantsLayer = true
+
+        let blur = NSVisualEffectView(frame: container.bounds)
+        blur.material = .hudWindow
+        blur.blendingMode = .behindWindow
+        blur.state = .active
+        blur.wantsLayer = true
+        blur.layer?.cornerRadius = 18 
+        blur.layer?.masksToBounds = true
+        blur.autoresizingMask = [.width, .height]
+        container.addSubview(blur)
+
+        let iv = NSImageView(frame: NSRect(x: 0, y: 76, width: hudSize.width, height: 80))
+        iv.imageScaling = .scaleProportionallyUpOrDown
+        iv.autoresizingMask = [.minXMargin, .maxXMargin]
+        blur.addSubview(iv)
+        iconView = iv
+
+        let tf = NSTextField(frame: NSRect(x: 0, y: 32, width: hudSize.width, height: 24))
+        tf.isEditable = false
+        tf.isBordered = false
+        tf.isBezeled = false
+        tf.drawsBackground = false
+        tf.alignment = .center
+        tf.font = .systemFont(ofSize: 18, weight: .bold)
+        tf.textColor = NSColor(white: 1.0, alpha: 0.85) 
+        tf.autoresizingMask = [.minXMargin, .maxXMargin]
+        blur.addSubview(tf)
+        label = tf
+
+        return container
+    }
+
+    private func positionWindow() {
+        guard let screen = NSScreen.main else { return }
+        let screenFrame = screen.visibleFrame
+        let x = screenFrame.midX - hudSize.width / 2
+        let y = screenFrame.minY + 70
+        hudWindow.setFrameOrigin(NSPoint(x: x, y: y))
+    }
+
+    private func fadeOut() {
+        guard let layer = hudWindow.contentView?.layer else { return }
+        
+        CATransaction.begin()
+        CATransaction.setCompletionBlock { [weak self] in
+            // When animation completes naturally (not cancelled), hide the window
+            if layer.opacity == 0 {
+                self?.hudWindow.orderOut(nil)
+            }
+        }
+        
+        let anim = CABasicAnimation(keyPath: "opacity")
+        anim.fromValue = 1.0
+        anim.toValue = 0.0
+        anim.duration = 0.3
+        anim.timingFunction = CAMediaTimingFunction(name: .easeIn)
+        anim.fillMode = .forwards
+        anim.isRemovedOnCompletion = false
+        
+        layer.opacity = 0.0
+        layer.add(anim, forKey: "fade")
+        
+        CATransaction.commit()
+    }
+}

--- a/toggleMute/toggleMute/Controllers/SettingsViewController.swift
+++ b/toggleMute/toggleMute/Controllers/SettingsViewController.swift
@@ -13,6 +13,8 @@ class SettingsViewController: NSViewController {
     @IBOutlet var launchAtLoginCheckBox: NSButton!
     @IBOutlet weak var redMenuBarIconCheckBox: NSButton!
     @IBOutlet weak var redMenuBarBackgroundCheckBox: NSButton!
+    @IBOutlet weak var muteSoundCheckBox: NSButton!
+    @IBOutlet weak var showHudCheckBox: NSButton!
     @IBOutlet var quitButton: NSButton!
     @IBOutlet weak var shortcutSubView: NSView!
     @IBOutlet weak var versionLabel: NSTextField!
@@ -65,7 +67,10 @@ class SettingsViewController: NSViewController {
         } else {
             redMenuBarIconCheckBox.state = .off
         }
-        
+
+        muteSoundCheckBox.state = preferences.muteSoundEnabled ? .on : .off
+        showHudCheckBox.state = preferences.showHudEnabled ? .on : .off
+
         let recorder = KeyboardShortcuts.RecorderCocoa(for: .toggleMuteShortcut)
 
         recorder.translatesAutoresizingMaskIntoConstraints = false
@@ -131,6 +136,14 @@ class SettingsViewController: NSViewController {
     }
     
     
+    @IBAction func didTouchMuteSound(_ sender: NSButton) {
+        preferences.muteSoundEnabled = sender.state == .on
+    }
+
+    @IBAction func didTouchShowHud(_ sender: NSButton) {
+        preferences.showHudEnabled = sender.state == .on
+    }
+
     @IBAction func didTouchClose(_ sender: Any) {
         
         NSApplication.shared.terminate(nil)

--- a/toggleMute/toggleMute/Controllers/TouchBarController.swift
+++ b/toggleMute/toggleMute/Controllers/TouchBarController.swift
@@ -54,10 +54,10 @@ class TouchBarController {
                 
         if(isMuted) {
             defaults.set(false, forKey: "isMuted")
-            toggleMuteStateHard(setMute: true)
+            toggleMuteStateHard(setMute: true, playFeedback: false)
         } else {
             defaults.set(true, forKey: "isMuted")
-            toggleMuteStateHard(setMute: false)
+            toggleMuteStateHard(setMute: false, playFeedback: false)
         }
     
     }
@@ -99,7 +99,7 @@ class TouchBarController {
     }
     
     
-    func toggleMuteStateHard(setMute: Bool) {
+    func toggleMuteStateHard(setMute: Bool, playFeedback: Bool = true) {
         
         let button = delegateController.statusItem.button
         isMuted = defaults.bool(forKey: "isMuted")
@@ -122,6 +122,13 @@ class TouchBarController {
             }
             
             setNewVolume(newValue: unmuteVal)
+
+            DispatchQueue.main.async {
+                if playFeedback {
+                    SoundFeedbackManager.shared.playUnmute()
+                    MuteHUDWindowController.shared.show(muted: false)
+                }
+            }
             
         } else if(setMute && !isMuted) {
             
@@ -140,6 +147,13 @@ class TouchBarController {
             
             if(redMenuBarIconBackground){
                 button?.layer?.backgroundColor = CGColor(red: 1.0, green: 0, blue: 0 , alpha: 1.0)
+            }
+
+            DispatchQueue.main.async {
+                if playFeedback {
+                    SoundFeedbackManager.shared.playMute()
+                    MuteHUDWindowController.shared.show(muted: true)
+                }
             }
             
         }

--- a/toggleMute/toggleMute/Resources/Storyboard/Controllers.storyboard
+++ b/toggleMute/toggleMute/Resources/Storyboard/Controllers.storyboard
@@ -27,11 +27,11 @@
             <objects>
                 <viewController storyboardIdentifier="SettingsController" id="aIO-ci-xyZ" customClass="SettingsViewController" customModule="toggleMute" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="GQP-k5-Kfj">
-                        <rect key="frame" x="0.0" y="0.0" width="170" height="258"/>
+                        <rect key="frame" x="0.0" y="0.0" width="170" height="308"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="09C-uc-Vc0">
-                                <rect key="frame" x="18" y="87" width="119" height="18"/>
+                                <rect key="frame" x="18" y="137" width="119" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Launch at login" bezelStyle="regularSquare" imagePosition="left" inset="2" id="6xX-4F-EZv">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -42,7 +42,7 @@
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="T0j-LS-G9b">
-                                <rect key="frame" x="18" y="142" width="52" height="20"/>
+                                <rect key="frame" x="18" y="192" width="52" height="20"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Icon" bezelStyle="regularSquare" imagePosition="left" inset="2" id="ZwO-CH-Rfw">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -53,7 +53,7 @@
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="A66-Qf-44f">
-                                <rect key="frame" x="18" y="120" width="99" height="18"/>
+                                <rect key="frame" x="18" y="170" width="99" height="18"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="check" title="Background" bezelStyle="regularSquare" imagePosition="left" inset="2" id="FF6-0H-k9n">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
@@ -64,11 +64,11 @@
                                 </connections>
                             </button>
                             <customView fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="soj-dc-sHL" userLabel="ShortCutInput">
-                                <rect key="frame" x="20" y="196" width="130" height="24"/>
+                                <rect key="frame" x="20" y="246" width="130" height="24"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             </customView>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MJg-6Y-ReN">
-                                <rect key="frame" x="25" y="228" width="118" height="16"/>
+                                <rect key="frame" x="25" y="278" width="118" height="16"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Keyboard Shortcut" id="VpL-F4-C9d">
                                     <font key="font" metaFont="system"/>
@@ -77,7 +77,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="x7T-lh-nLC">
-                                <rect key="frame" x="18" y="165" width="89" height="16"/>
+                                <rect key="frame" x="18" y="215" width="89" height="16"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Red Menubar:" id="DEQ-ir-kkm">
                                     <font key="font" metaFont="system"/>
@@ -97,11 +97,11 @@
                                 </connections>
                             </button>
                             <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="w9j-5S-ZZS">
-                                <rect key="frame" x="12" y="187" width="147" height="5"/>
+                                <rect key="frame" x="12" y="237" width="147" height="5"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             </box>
                             <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="gWj-lX-r5E">
-                                <rect key="frame" x="12" y="110" width="147" height="5"/>
+                                <rect key="frame" x="12" y="160" width="147" height="5"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             </box>
                             <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="sYR-6q-5LN">
@@ -109,7 +109,7 @@
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             </box>
                             <box verticalHuggingPriority="750" fixedFrame="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ldF-az-ThK">
-                                <rect key="frame" x="12" y="77" width="147" height="5"/>
+                                <rect key="frame" x="12" y="127" width="147" height="5"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                             </box>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Tqi-fB-Duh">
@@ -136,10 +136,36 @@
                                 <imageCell key="cell" focusRingType="none" alignment="left" imageScaling="proportionallyDown" image="heart.fill" catalog="system" id="rAY-C7-Wzq"/>
                                 <color key="contentTintColor" name="controlAccentColor" catalog="System" colorSpace="catalog"/>
                             </imageView>
+                            <!-- Sound feedback checkbox -->
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Sf1-mS-ch1">
+                                <rect key="frame" x="18" y="107" width="142" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="Play sound on mute/unmute" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Sf1-mS-ch2">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="didTouchMuteSound:" target="aIO-ci-xyZ" id="Sf1-mS-ch3"/>
+                                </connections>
+                            </button>
+                            <!-- HUD overlay checkbox -->
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hd1-oV-wd1">
+                                <rect key="frame" x="18" y="87" width="142" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="check" title="Show mute overlay" bezelStyle="regularSquare" imagePosition="left" inset="2" id="Hd1-oV-wd2">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="didTouchShowHud:" target="aIO-ci-xyZ" id="Hd1-oV-wd3"/>
+                                </connections>
+                            </button>
                         </subviews>
                     </view>
                     <connections>
                         <outlet property="launchAtLoginCheckBox" destination="09C-uc-Vc0" id="26M-gn-LQB"/>
+                        <outlet property="muteSoundCheckBox" destination="Sf1-mS-ch1" id="Sf1-mS-out"/>
+                        <outlet property="showHudCheckBox" destination="Hd1-oV-wd1" id="Hd1-oV-out"/>
                         <outlet property="quitButton" destination="J5i-rV-IWc" id="FAg-qz-Z3W"/>
                         <outlet property="redMenuBarBackgroundCheckBox" destination="A66-Qf-44f" id="Lp5-Gg-ejx"/>
                         <outlet property="redMenuBarIconCheckBox" destination="T0j-LS-G9b" id="Q9e-U6-5NJ"/>

--- a/toggleMute/toggleMute/Support/Preferences.swift
+++ b/toggleMute/toggleMute/Support/Preferences.swift
@@ -18,6 +18,22 @@ struct Preferences {
         }
     }
 
+    var muteSoundEnabled: Bool {
+        get { defaults.bool(forKey: #function) }
+        set {
+            defaults.set(newValue, forKey: #function)
+            didChange()
+        }
+    }
+
+    var showHudEnabled: Bool {
+        get { defaults.bool(forKey: #function) }
+        set {
+            defaults.set(newValue, forKey: #function)
+            didChange()
+        }
+    }
+
     private var appURL: URL { Bundle.main.bundleURL }
     
     var launchAtLoginEnabled: Bool {

--- a/toggleMute/toggleMute/Support/SoundFeedbackManager.swift
+++ b/toggleMute/toggleMute/Support/SoundFeedbackManager.swift
@@ -1,0 +1,41 @@
+// Plays a short audio cue on mute/unmute using AppKit's NSSound — zero extra frameworks.
+
+import Cocoa
+
+final class SoundFeedbackManager {
+
+    static let shared = SoundFeedbackManager()
+    private var preferences = Preferences()
+
+    // Pre-load both sounds once so playback is instant.
+    private let muteSound: NSSound? = {
+        if let s = NSSound(named: NSSound.Name("Tink")) {
+            s.volume = 0.6
+            return s
+        }
+        return nil
+    }()
+
+    private let unmuteSound: NSSound? = {
+        if let s = NSSound(named: NSSound.Name("Pop")) {
+            s.volume = 0.6
+            return s
+        }
+        return nil
+    }()
+
+    private init() {}
+
+    func playMute() {
+        guard preferences.muteSoundEnabled else { return }
+        // Stop any previous playback first so rapid toggling doesn't queue up sounds
+        muteSound?.stop()
+        muteSound?.play()
+    }
+
+    func playUnmute() {
+        guard preferences.muteSoundEnabled else { return }
+        unmuteSound?.stop()
+        unmuteSound?.play()
+    }
+}


### PR DESCRIPTION
## Overview
Adds optional on-screen and sound feedback for mute/unmute.

## Changes
- Native HUD overlay using `NSVisualEffectView` (`.hudWindow`) and `SF Symbols`
- Lightweight `NSSound` feedback (preloaded, no overlap)
- Two new toggles in Settings:
  - Show mute overlay
  - Play sound on mute/unmute