### PR TITLE
Fix mute on Aggregate Devices (use CoreAudio mute property)

### DIFF
--- a/toggleMute/toggleMute.xcodeproj/project.pbxproj
+++ b/toggleMute/toggleMute.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		BD391AE9263C3F5600848049 /* LaunchAtLogin in Frameworks */ = {isa = PBXBuildFile; productRef = BD391AE8263C3F5600848049 /* LaunchAtLogin */; };
 		C3C528C02DF0162800BBC393 /* KeyboardShortcuts in Frameworks */ = {isa = PBXBuildFile; productRef = C3C528BF2DF0162800BBC393 /* KeyboardShortcuts */; };
 		C3DA000A2B88C00900B6BCCA /* EventMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3DA00092B88C00900B6BCCA /* EventMonitor.swift */; };
+		D9A1F4022E0099AA00112233 /* AudioInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9A1F4012E0099AA00112233 /* AudioInputController.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -51,6 +52,7 @@
 		44EB8BD723AC2ABD005A4A0B /* TouchBarController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchBarController.swift; sourceTree = "<group>"; };
 		44EB8BDB23AC350D005A4A0B /* SettingsViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsViewController.swift; sourceTree = "<group>"; };
 		C3DA00092B88C00900B6BCCA /* EventMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventMonitor.swift; sourceTree = "<group>"; };
+		D9A1F4012E0099AA00112233 /* AudioInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioInputController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -130,6 +132,7 @@
 				44D551DF2390830E0065505A /* SharedFileList.h */,
 				44D551DE2390830E0065505A /* SharedFileList.m */,
 				449F398223173003008A0DBD /* Preferences.swift */,
+				D9A1F4012E0099AA00112233 /* AudioInputController.swift */,
 				44D551DD2390830E0065505A /* SettingsController-Bridging-Header.h */,
 				44EB8BD623AC28E3005A4A0B /* NSTouchBar-Private.h */,
 			);
@@ -274,6 +277,7 @@
 				449F398D23173610008A0DBD /* SettingsController.swift in Sources */,
 				449F398323173003008A0DBD /* Preferences.swift in Sources */,
 				C3DA000A2B88C00900B6BCCA /* EventMonitor.swift in Sources */,
+				D9A1F4022E0099AA00112233 /* AudioInputController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/toggleMute/toggleMute/Bootstrap/AppDelegate.swift
+++ b/toggleMute/toggleMute/Bootstrap/AppDelegate.swift
@@ -199,12 +199,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
     @objc func runTimedCode(){
 
         mainController.getCurrentVolume()
-                
-        if(defaults.integer(forKey: "currentSetVolume") < 5) {
-            touchBarController.toggleMuteStateHard(setMute: true)
-        } else {
-            touchBarController.toggleMuteStateHard(setMute: false)
-        }
+
+        // Sync UI to the actual device state so the icon reflects external mute
+        // changes (e.g. from the system menu). Reads the real CoreAudio mute
+        // property — falls back to "volume == 0" only when no mute property is
+        // exposed. If we can't tell, leave the UI alone instead of flipping it.
+        guard let muted = AudioInputController.isMuted() else { return }
+        touchBarController.toggleMuteStateHard(setMute: muted)
 
     }
     

--- a/toggleMute/toggleMute/Controllers/MainController.swift
+++ b/toggleMute/toggleMute/Controllers/MainController.swift
@@ -103,23 +103,17 @@ class MainController: NSViewController, UNUserNotificationCenterDelegate {
 
     
     func getCurrentVolume() {
-        
-        let setInputVolume = "return input volume of (get volume settings)"
-        var error: NSDictionary?
-                
-        if let scriptObject = NSAppleScript(source: setInputVolume) {
-            
-            if let outputString = scriptObject.executeAndReturnError(&error).stringValue {
-                
-                currentSetVolume = Int(outputString)!
-                defaults.set(currentSetVolume, forKey: "currentSetVolume")
-                
-            } else if (error != nil) {
-                // no error handling currently as it just works always :D
-            }
-            
+        // AppleScript's `input volume of (get volume settings)` is unreliable on
+        // Aggregate Devices (often returns a stale 100). Read the actual input
+        // volume via CoreAudio. If muted, report 0 so the slider/UI reflects it.
+        if AudioInputController.isMuted() == true {
+            currentSetVolume = 0
+        } else if let v = AudioInputController.volume() {
+            currentSetVolume = Int((v * 100).rounded())
+        } else {
+            return
         }
-        
+        defaults.set(currentSetVolume, forKey: "currentSetVolume")
     }
     
     

--- a/toggleMute/toggleMute/Controllers/TouchBarController.swift
+++ b/toggleMute/toggleMute/Controllers/TouchBarController.swift
@@ -74,18 +74,12 @@ class TouchBarController {
     
     
     func setNewVolume(newValue: Int) {
-                    
-       let setInputAndResetOutputVolume =
-            """
-            set volume input volume \(newValue)
-            set currentVol to output volume of (get volume settings)
-            set volume output volume currentVol
-            """
-        var error: NSDictionary?
-        if let scriptObject = NSAppleScript(source: setInputAndResetOutputVolume) {
-           scriptObject.executeAndReturnError(&error)
-        }
-                    
+        // Drives the *gain* of the default input device (used when restoring the
+        // user's preferred input volume on unmute, and when the slider moves).
+        // AppleScript's `set volume input volume` is a no-op on Aggregate Devices,
+        // so go through CoreAudio.
+        let clamped = max(0, min(100, newValue))
+        AudioInputController.setVolume(Float32(clamped) / 100.0)
     }
     
 
@@ -107,41 +101,43 @@ class TouchBarController {
         redMenuBarIcon = defaults.bool(forKey: "redMenuBarIcon")
                 
         if(!setMute && isMuted){
-        
+
             defaults.set(false, forKey: "isMuted")
-            
+
             button?.image = imageUnmute?.tint(color: .alternateSelectedControlTextColor)
-            
+
             button?.layer?.backgroundColor = CGColor(red: 0, green: 0, blue: 0 , alpha: 0)
             touchBarButton?.image = imageUnmute
             touchBarButton?.bezelColor = NSColor.clear
+
+            AudioInputController.setMuted(false)
+
             var unmuteVal = 80
-            
             if(isKeyPresentInUserDefaults(key: "defaultInputVol")){
                 unmuteVal = defaults.integer(forKey: "defaultInputVol")
             }
-            
             setNewVolume(newValue: unmuteVal)
-            
+
         } else if(setMute && !isMuted) {
-            
+
             defaults.set(true, forKey: "isMuted")
-                    
+
             button?.image = imageMute?.tint(color: .selectedMenuItemTextColor)
             button?.layer?.backgroundColor = CGColor(red: 0, green: 0, blue: 0 , alpha: 0)
-            
+
             touchBarButton?.image = imageMute
             touchBarButton?.bezelColor = NSColor.red
-            setNewVolume(newValue: 0)
-            
+
+            AudioInputController.setMuted(true)
+
             if(redMenuBarIcon){
                 button?.image = imageMute?.tint(color: .red)
             }
-            
+
             if(redMenuBarIconBackground){
                 button?.layer?.backgroundColor = CGColor(red: 1.0, green: 0, blue: 0 , alpha: 1.0)
             }
-            
+
         }
         
     }

--- a/toggleMute/toggleMute/Support/AudioInputController.swift
+++ b/toggleMute/toggleMute/Support/AudioInputController.swift
@@ -1,0 +1,255 @@
+import Foundation
+import CoreAudio
+
+/// CoreAudio-backed control for the default input device.
+/// Handles Aggregate Devices by dispatching mute/volume to their input sub-devices,
+/// since AppleScript `set volume input volume` is a no-op on most aggregates.
+enum AudioInputController {
+
+    // MARK: - Public API
+
+    static func setMuted(_ muted: Bool) {
+        guard let deviceID = defaultInputDeviceID() else { return }
+        applyMute(deviceID: deviceID, muted: muted)
+    }
+
+    static func isMuted() -> Bool? {
+        guard let deviceID = defaultInputDeviceID() else { return nil }
+        return readMute(deviceID: deviceID)
+    }
+
+    /// `volume` is 0.0 ... 1.0
+    static func setVolume(_ volume: Float32) {
+        guard let deviceID = defaultInputDeviceID() else { return }
+        applyVolume(deviceID: deviceID, volume: volume)
+    }
+
+    /// Returns 0.0 ... 1.0, or nil if no readable volume property is present.
+    static func volume() -> Float32? {
+        guard let deviceID = defaultInputDeviceID() else { return nil }
+        return readVolume(deviceID: deviceID)
+    }
+
+    // MARK: - Device lookup
+
+    private static func defaultInputDeviceID() -> AudioDeviceID? {
+        var id: AudioDeviceID = kAudioObjectUnknown
+        var size = UInt32(MemoryLayout<AudioDeviceID>.size)
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioHardwarePropertyDefaultInputDevice,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &address, 0, nil, &size, &id
+        )
+        guard status == noErr, id != kAudioObjectUnknown else { return nil }
+        return id
+    }
+
+    private static func subDeviceIDs(of aggregate: AudioDeviceID) -> [AudioDeviceID] {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioAggregateDevicePropertyActiveSubDeviceList,
+            mScope: kAudioObjectPropertyScopeGlobal,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        guard AudioObjectHasProperty(aggregate, &address) else { return [] }
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(aggregate, &address, 0, nil, &size) == noErr,
+              size > 0 else { return [] }
+        let count = Int(size) / MemoryLayout<AudioDeviceID>.size
+        var ids = [AudioDeviceID](repeating: kAudioObjectUnknown, count: count)
+        guard AudioObjectGetPropertyData(aggregate, &address, 0, nil, &size, &ids) == noErr else {
+            return []
+        }
+        return ids
+    }
+
+    private static func hasInputStream(_ deviceID: AudioDeviceID) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreams,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        let status = AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &size)
+        return status == noErr && size > 0
+    }
+
+    private static func inputChannelCount(_ deviceID: AudioDeviceID) -> UInt32 {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyStreamConfiguration,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: kAudioObjectPropertyElementMain
+        )
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(deviceID, &address, 0, nil, &size) == noErr,
+              size > 0 else { return 0 }
+        let raw = UnsafeMutableRawPointer.allocate(
+            byteCount: Int(size),
+            alignment: MemoryLayout<AudioBufferList>.alignment
+        )
+        defer { raw.deallocate() }
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, raw) == noErr else {
+            return 0
+        }
+        let abl = UnsafeMutableAudioBufferListPointer(
+            raw.assumingMemoryBound(to: AudioBufferList.self)
+        )
+        var total: UInt32 = 0
+        for buffer in abl { total += buffer.mNumberChannels }
+        return total
+    }
+
+    // MARK: - Mute
+
+    private static func applyMute(deviceID: AudioDeviceID, muted: Bool) {
+        let subs = subDeviceIDs(of: deviceID)
+        let targets = subs.isEmpty ? [deviceID] : subs.filter(hasInputStream)
+        for target in targets {
+            if !setMuteProperty(target, muted: muted) {
+                // Fallback when the device exposes no writable mute: drive volume to 0/1.
+                _ = setVolumeProperty(target, volume: muted ? 0 : 1)
+            }
+        }
+    }
+
+    private static func setMuteProperty(_ deviceID: AudioDeviceID, muted: Bool) -> Bool {
+        if writeMute(deviceID, channel: kAudioObjectPropertyElementMain, muted: muted) {
+            return true
+        }
+        let channels = inputChannelCount(deviceID)
+        guard channels > 0 else { return false }
+        var anyOK = false
+        for ch in 1...channels {
+            if writeMute(deviceID, channel: ch, muted: muted) { anyOK = true }
+        }
+        return anyOK
+    }
+
+    private static func writeMute(_ deviceID: AudioDeviceID, channel: UInt32, muted: Bool) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyMute,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: channel
+        )
+        guard AudioObjectHasProperty(deviceID, &address) else { return false }
+        var settable: DarwinBoolean = false
+        guard AudioObjectIsPropertySettable(deviceID, &address, &settable) == noErr,
+              settable.boolValue else { return false }
+        var value: UInt32 = muted ? 1 : 0
+        let size = UInt32(MemoryLayout<UInt32>.size)
+        return AudioObjectSetPropertyData(deviceID, &address, 0, nil, size, &value) == noErr
+    }
+
+    private static func readMute(deviceID: AudioDeviceID) -> Bool? {
+        let subs = subDeviceIDs(of: deviceID)
+        let targets = subs.isEmpty ? [deviceID] : subs.filter(hasInputStream)
+        for target in targets {
+            if let m = readMuteOnDevice(target) { return m }
+        }
+        // Fallback: infer mute from volume == 0
+        for target in targets {
+            if let v = readVolumeOnDevice(target) { return v < 0.05 }
+        }
+        return nil
+    }
+
+    private static func readMuteOnDevice(_ deviceID: AudioDeviceID) -> Bool? {
+        if let v = queryMute(deviceID, channel: kAudioObjectPropertyElementMain) { return v }
+        let channels = inputChannelCount(deviceID)
+        guard channels > 0 else { return nil }
+        for ch in 1...channels {
+            if let v = queryMute(deviceID, channel: ch) { return v }
+        }
+        return nil
+    }
+
+    private static func queryMute(_ deviceID: AudioDeviceID, channel: UInt32) -> Bool? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyMute,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: channel
+        )
+        guard AudioObjectHasProperty(deviceID, &address) else { return nil }
+        var value: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &value) == noErr else {
+            return nil
+        }
+        return value != 0
+    }
+
+    // MARK: - Volume
+
+    private static func applyVolume(deviceID: AudioDeviceID, volume: Float32) {
+        let clamped = max(0, min(1, volume))
+        let subs = subDeviceIDs(of: deviceID)
+        let targets = subs.isEmpty ? [deviceID] : subs.filter(hasInputStream)
+        for target in targets {
+            _ = setVolumeProperty(target, volume: clamped)
+        }
+    }
+
+    private static func setVolumeProperty(_ deviceID: AudioDeviceID, volume: Float32) -> Bool {
+        if writeVolume(deviceID, channel: kAudioObjectPropertyElementMain, volume: volume) {
+            return true
+        }
+        let channels = inputChannelCount(deviceID)
+        guard channels > 0 else { return false }
+        var anyOK = false
+        for ch in 1...channels {
+            if writeVolume(deviceID, channel: ch, volume: volume) { anyOK = true }
+        }
+        return anyOK
+    }
+
+    private static func writeVolume(_ deviceID: AudioDeviceID, channel: UInt32, volume: Float32) -> Bool {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: channel
+        )
+        guard AudioObjectHasProperty(deviceID, &address) else { return false }
+        var settable: DarwinBoolean = false
+        guard AudioObjectIsPropertySettable(deviceID, &address, &settable) == noErr,
+              settable.boolValue else { return false }
+        var value = volume
+        let size = UInt32(MemoryLayout<Float32>.size)
+        return AudioObjectSetPropertyData(deviceID, &address, 0, nil, size, &value) == noErr
+    }
+
+    private static func readVolume(deviceID: AudioDeviceID) -> Float32? {
+        let subs = subDeviceIDs(of: deviceID)
+        let targets = subs.isEmpty ? [deviceID] : subs.filter(hasInputStream)
+        for target in targets {
+            if let v = readVolumeOnDevice(target) { return v }
+        }
+        return nil
+    }
+
+    private static func readVolumeOnDevice(_ deviceID: AudioDeviceID) -> Float32? {
+        if let v = queryVolume(deviceID, channel: kAudioObjectPropertyElementMain) { return v }
+        let channels = inputChannelCount(deviceID)
+        guard channels > 0 else { return nil }
+        for ch in 1...channels {
+            if let v = queryVolume(deviceID, channel: ch) { return v }
+        }
+        return nil
+    }
+
+    private static func queryVolume(_ deviceID: AudioDeviceID, channel: UInt32) -> Float32? {
+        var address = AudioObjectPropertyAddress(
+            mSelector: kAudioDevicePropertyVolumeScalar,
+            mScope: kAudioDevicePropertyScopeInput,
+            mElement: channel
+        )
+        guard AudioObjectHasProperty(deviceID, &address) else { return nil }
+        var value: Float32 = 0
+        var size = UInt32(MemoryLayout<Float32>.size)
+        guard AudioObjectGetPropertyData(deviceID, &address, 0, nil, &size, &value) == noErr else {
+            return nil
+        }
+        return value
+    }
+}


### PR DESCRIPTION
## Summary

Pressing the toggleMute hotkey while an **Aggregate Device** is the default input doesn't actually mute the mic. The menu bar icon briefly flashes red, then reverts to unmuted ~1 second later. This PR fixes that.

## Why this matters

A common macOS workaround for the auto-switching-input-to-Bluetooth-headphones annoyance is to create an Aggregate Device that wraps your built-in mic, and set that as the system input — so the system never switches away from your real mic when AirPods/headphones connect. See e.g. [this r/MacOS comment](https://www.reddit.com/r/MacOS/comments/1jvbf7d/comment/nn7fgtx/) which is the recipe a lot of people land on. Anyone using that workaround currently can't use toggleMute.

## Root cause

Two things conspire:

1. **AppleScript `set volume input volume 0` is a no-op on Aggregate Devices.** Aggregates don't expose a writable master volume — they delegate to their sub-devices — so the AppleScript silently does nothing. A regular USB/built-in mic implements the property directly, which is why those work.
2. **The 1-second watchdog timer in `AppDelegate.runTimedCode` overrides the UI.** It reads input volume via the same broken AppleScript path; for aggregates the read returns a stale ~100, so it flips the icon back to "unmuted" right after you tried to mute.

## Fix

New `AudioInputController` (Support/) that drives mute and volume via CoreAudio:

- Resolves the default input device, detects whether it's an aggregate, and dispatches `kAudioDevicePropertyMute` / `kAudioDevicePropertyVolumeScalar` to each input-bearing sub-device.
- Tries the master element first, then per-channel; if no writable mute property exists on a device, falls back to driving volume to 0.
- `TouchBarController.toggleMuteStateHard` and `setNewVolume` now go through `AudioInputController` instead of AppleScript.
- `AppDelegate.runTimedCode` and `MainController.getCurrentVolume` read real mute/volume state via CoreAudio. If the state can't be read, the watchdog leaves the UI alone (no more flip-back).

No change to the behaviour with non-aggregate devices — those paths still work as before.

## Tested

Built and ran locally on macOS (Apple Silicon), with an Aggregate Device set as default input. Confirmed:
- Hotkey now mutes and stays muted; menu bar icon stays red.
- Hotkey unmutes correctly.
- Restoring the user's preferred input volume on unmute still works.
- Regular built-in mic still works as before.

## Test plan

- [ ] Set the default input to a regular device (built-in mic, USB mic); hotkey mutes/unmutes as before.
- [ ] Open Audio MIDI Setup → create an Aggregate Device → set it as default input. Hotkey should now mute and stay muted, and unmute restores volume.
- [ ] Slider in the popover still adjusts input volume.
- [ ] Mute toggled externally (e.g. via system menu) is reflected in the menu bar icon within ~1s.